### PR TITLE
Capitalization for valid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ I work on this integration because I like things to work well for myself and oth
 
 # Documentation
 
-The full documentation is available here - [MS365 To Do Documentation](https://rogerselwyn.github.io/ms365-todo/)
+The full documentation is available here - [MS365 To Do Documentation](https://rogerselwyn.github.io/MS365-ToDo/)


### PR DESCRIPTION
When I was clicking the link in the readme it would bring me to a 404. I noticed your calendar integration had capitalization which I used on this URL to find the proper documentation pages.